### PR TITLE
Update MTHandlers.java

### DIFF
--- a/src/main/java/ru/lionzxy/damagetweaker/MTHandlers.java
+++ b/src/main/java/ru/lionzxy/damagetweaker/MTHandlers.java
@@ -76,7 +76,7 @@ public class MTHandlers {
 
 
     public static String[] splitString(String original, char split) {
-        return Write.spilitToByte(original, (byte) split);
+        return Write.splitToByte(original, (byte) split);
     }
 
     @ZenMethod


### PR DESCRIPTION
splitString() name fix
